### PR TITLE
If module does not exist, don't fail

### DIFF
--- a/googleCharts.js
+++ b/googleCharts.js
@@ -38,6 +38,6 @@ class googleCharts {
 
 export let GoogleCharts = new googleCharts();
 
-if (module.hot) {
+if ((typeof module !== 'undefined') && module.hot) {
     module.hot.accept();
 }


### PR DESCRIPTION
It's possible that module does not exist, in which case the import fails with a reference error. I observed this behavior with polymer 3, but when I add the shown check, everything works fine.