### PR TITLE
Allow the load function to accept a config object

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,8 +48,12 @@ GoogleCharts.load(drawCharts);
 /* 
 * Load a specific type(s) of chart(s). You can call this as many times as you need from anywhere in your app
 * GoogleCharts is a singleton and will not allow the script to be loaded more than once
+* The mapsApiKey is only required for certain GeoCharts
 */
-GoogleCharts.load(drawGeoChart, 'geochart');
+GoogleCharts.load(drawGeoChart, {
+    'packages': ['geochart'],
+    'mapsApiKey': 'YOUR_API_KEY'
+});
 
 function drawCharts() {
 

--- a/googleCharts.js
+++ b/googleCharts.js
@@ -24,10 +24,15 @@ class googleCharts {
     load(callback, type) {
         return this[loadScript]().then(() => {
             if (type) {
-                if(!Array.isArray(type)) {
-                    type=[type]
+                let config = {};
+                if(type instanceof Object) {
+                    config = type;
+                } else if(Array.isArray(type)) {
+                    config = {'packages': type}
+                } else {
+                    config = {'packages': [type]}
                 }
-                this.api.charts.load('current', {'packages': type})
+                this.api.charts.load('current', config)
                 this.api.charts.setOnLoadCallback(callback)
             } else {
                 callback()


### PR DESCRIPTION
For some GeoCharts a mapsApiKey is required to be passed to the load
function. This allows for an object to be be passed to GoogleCharts.load()
instead of just a string or Array.