### PR TITLE
Fix uncaught syntax error with export function

### DIFF
--- a/googleCharts.js
+++ b/googleCharts.js
@@ -41,7 +41,7 @@ class googleCharts {
     }
 }
 
-export let GoogleCharts = new googleCharts();
+module.exports = googleCharts
 
 if ((typeof module !== 'undefined') && module.hot) {
     module.hot.accept();


### PR DESCRIPTION
Replace export on line 44 with module.exports to prevent syntax error

Fix for Issue #15 